### PR TITLE
Replace vulnerable spring-data-commons dependency by a newer one

### DIFF
--- a/bootcamp/pom.xml
+++ b/bootcamp/pom.xml
@@ -16,7 +16,7 @@
 		<hazelcast.version>3.9</hazelcast.version>
 		<hazelcast-spring.version>3.9</hazelcast-spring.version>
 		<java.version>8</java.version>
-		<spring-data-commons.version>1.12.5.RELEASE</spring-data-commons.version>
+		<spring-data-commons.version>1.13.17.RELEASE</spring-data-commons.version>
 		<spring-data-hazelcast.version>1.0</spring-data-hazelcast.version>
 		<spring-data-keyvalue.version>1.1.5.RELEASE</spring-data-keyvalue.version>
 	</properties>


### PR DESCRIPTION
Addresses the https://www.cvedetails.com/cve/CVE-2018-1274/